### PR TITLE
[codex] add mistship commit workflow skills

### DIFF
--- a/.agents/skills/mistship-commit-secret-reviewer/SKILL.md
+++ b/.agents/skills/mistship-commit-secret-reviewer/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: mistship-commit-secret-reviewer
+description: Review the staged diff in the mistship-manifests repository for secrets and real operational identifiers. Use this skill immediately before every git commit and fail closed when suspicious content is present.
+---
+
+# Commit Secret Reviewer
+
+コミット前に staged diff を検査し、秘匿情報や実運用情報がコミットへ含まれていないことを確認するレビュー用サブエージェントの定義です。
+
+このリポジトリは Private repository 前提で運用します。ただし、秘密鍵や実 IP
+アドレスなど、漏えい時の影響が大きい秘匿情報はコミット禁止情報として扱います。
+Discord incoming webhook URL のように権限が投稿に限定される通知先 URL は、
+所有者が用途とリスクを確認した場合に限りコミットを許容します。
+
+## 目的
+
+- コミットへ入る差分だけを対象に秘匿情報の混入を検出する
+- 人手レビュー前に明確な fail 条件をそろえる
+- 誤検知より漏えい防止を優先する
+
+## 呼び出しタイミング
+
+- `git commit` の直前に毎回実行する
+- 対象は `staged diff` のみとする
+- unstaged 変更、untracked file、repo 全体は対象外とする
+
+## 入力契約
+
+サブエージェントには最低限、次を渡します。
+
+- `git diff --cached --no-color --binary` の出力
+- `git diff --cached --name-only` の出力
+- 存在する場合は repo ルートの `.codex-secret-review-allowlist.yaml`
+
+差分が空なら `PASS` を返します。
+
+## 実行コマンド
+
+`git commit` の直前に、repo ルートで次を実行してレビュー入力を取得します。
+
+```sh
+git diff --cached --name-only
+git diff --cached --no-color --binary
+if [ -f .codex-secret-review-allowlist.yaml ]; then
+  cat .codex-secret-review-allowlist.yaml
+fi
+```
+
+対象は staged diff のみです。`git diff` のみを実行して unstaged diff を検査対象にしたり、
+`git diff HEAD` で staged diff と unstaged diff を混ぜたりしません。
+
+レビュー中に追加修正や `git add` を行った場合は、古いレビュー結果を使わず、上記コマンドを
+再実行してからもう一度レビューします。
+
+## 判定方針
+
+- 疑わしければ `FAIL` とする
+- 既知の秘密情報、実運用情報、再生成可能でも公開したくない運用情報を検出対象にする
+- 低権限の通知先 URL は、Private repo 前提かつ所有者の明示的な許可がある場合だけ許容する
+- 許可された例外は allowlist で明示する
+
+## Fail ルール
+
+### `FILE_SECRET`
+
+次のようなファイル名やパスが追加・変更されたら `FAIL` とします。
+
+- `talosconfig`
+- `kubeconfig`
+- 平文の `cluster-secrets.yaml`
+- `.secret/`
+- `*.pem`
+- `*.key`
+- `*.p12`
+- `*.pfx`
+- `*.agekey`
+- `id_rsa`
+- `id_ed25519`
+- 鍵、証明書、token dump、secret bundle を想起させるファイル名
+
+ただし、`secrets/**/*.sops.yaml` と `secrets/**/*.sops.env` は暗号化済み blob として扱い、private key や平文 secret が含まれていなければ `FILE_SECRET` では fail しません。
+また、`sealed-secrets/mistship-sealed-secrets.crt` は Sealed Secrets の公開鍵として扱い、private key でないことが明らかなら `FILE_SECRET` では fail しません。
+
+### `KEY_MATERIAL`
+
+追加行に次のような鍵や証明書本文が含まれたら `FAIL` とします。
+
+- `-----BEGIN`
+- `OPENSSH PRIVATE KEY`
+- `AGE-SECRET-KEY-1`
+- `tls.key`
+- `client-certificate-data`
+- `client-key-data`
+
+Base64 文字列でも、文脈上で鍵や証明書を保持していると判断できる場合は `FAIL` とします。
+
+ただし、`sealed-secrets/mistship-sealed-secrets.crt` にある Sealed Secrets の公開証明書は例外として許可します。秘密鍵や client certificate を含めてはいけません。
+
+### `CONFIG_SECRET`
+
+Talos や Kubernetes の設定実体が差分へ入ったら `FAIL` とします。
+
+- `apiVersion: v1` と `clusters:` `users:` `contexts:` を含む `kubeconfig`
+- `contexts:` `endpoints:` `nodes:` を含む `talosconfig`
+- Secret manifest や bootstrap token の実体
+- 認証 header、bearer token、password、client secret、join token
+
+ただし、Discord incoming webhook URL は、この Private repo では通知投稿のみの
+低権限 URL として扱います。所有者が用途とリスクを確認している場合は
+`CONFIG_SECRET` では fail しません。
+
+### `REAL_IP`
+
+実運用 IP アドレスが差分へ入ったら `FAIL` とします。
+
+許可するのは文書用またはローカル用途の次だけです。
+
+- RFC 5737: `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`
+- RFC 3849: `2001:db8::/32`
+- `127.0.0.0/8`
+- `::1`
+- `0.0.0.0`
+
+次は `FAIL` とします。
+
+- RFC1918 の実アドレス
+- ULA を含む実 IPv6
+- グローバル IP
+- VIP や実 FQDN と組み合わさった IP
+
+### `HIGH_ENTROPY`
+
+次のような、秘密情報である可能性が高い高 entropy 文字列は `FAIL` とします。
+
+- 長い base64 文字列
+- ランダムに見える token
+- YAML や JSON に埋め込まれた認証文字列
+
+用途が説明できない長いランダム値は、人手確認が必要な `FAIL` とします。
+
+ただし、Discord incoming webhook URL に含まれる token-like 文字列は、この
+Private repo では所有者の明示的な許可がある場合に限り `HIGH_ENTROPY` では
+fail しません。
+
+### `ALLOWLIST_MISSING`
+
+誤検知を回避する必要があるのに allowlist へ記録がない場合は `FAIL` とします。
+
+## Allowlist
+
+例外は repo ルートの `.codex-secret-review-allowlist.yaml` で管理します。
+
+目的は誤検知の抑制であり、秘密情報の持ち込みを正当化するためには使いません。
+
+各エントリの必須項目:
+
+- `path`
+- `pattern`
+- `reason`
+- `owner`
+- `expires_on`
+
+例:
+
+```yaml
+allowlist:
+  - path: docs/bootstrap.md
+    pattern: 192.0.2.11
+    reason: RFC 5737 の文書用アドレスを例として使うため
+    owner: azuki
+    expires_on: 2026-12-31
+```
+
+次の場合は allowlist に一致しても `FAIL` とします。
+
+- `reason` が空
+- `owner` が空
+- `expires_on` がない
+- `expires_on` が期限切れ
+- `path` が一致しない
+- 実際には秘密情報で、例外化すべきではない
+
+## 出力契約
+
+サブエージェントは `PASS` または `FAIL` を返します。
+
+`FAIL` の場合は finding ごとに次を含めます。
+
+- `severity`
+- `path`
+- `line_hint`
+- `rule_id`
+- `evidence_summary`
+- `suggested_fix`
+
+出力例:
+
+```text
+FAIL
+
+- severity: high
+  path: docs/bootstrap.md
+  line_hint: added line containing 10.0.0.12
+  rule_id: REAL_IP
+  evidence_summary: RFC1918 address was added to a public document.
+  suggested_fix: Replace with an RFC 5737 example address or move the value outside Git.
+```
+
+複数の finding がある場合は、すべて列挙します。
+
+## 実行手順
+
+1. `git diff --cached --name-only` で staged file list を読む
+2. `git diff --cached --no-color --binary` で staged diff の追加行を中心に検査する
+3. ファイル名ベースの禁止対象を先に落とす
+4. 本文内の鍵、設定実体、IP、token、base64 blob を検査する
+5. `.codex-secret-review-allowlist.yaml` が存在する場合だけ内容を読み、allowlist を適用する
+6. レビュー開始後に staged diff が変わっていないことを確認する。変わった場合は最初からやり直す
+7. `PASS` または `FAIL` を返す
+
+## サブエージェントへの指示文
+
+以下をそのままレビューエージェントの基本指示として使えます。
+
+```text
+You are commit-secret-reviewer. Review only the staged diff for this repository before commit.
+This is a private repository. Fail closed for high-impact secrets or real operational identifiers.
+Check file paths first, then added lines, then apply the repo allowlist if present.
+Treat real IP addresses, keys, kubeconfig, talosconfig, token-like strings, and secret bundles as forbidden.
+Allow low-privilege notification endpoint URLs, such as Discord incoming webhook URLs, only when the owner explicitly confirmed the purpose and risk.
+Allow only documentation-safe placeholder addresses such as RFC 5737 and RFC 3849 examples, localhost, and unspecified addresses.
+Return PASS or FAIL. On FAIL, enumerate findings with severity, path, line_hint, rule_id, evidence_summary, and suggested_fix.
+```
+
+## 非対象
+
+この定義には次を含めません。
+
+- CI 側の再検査
+- 実際の git hook 実装
+- 履歴改変や secret revoke 手順
+- repo 全体の定期スキャン

--- a/.agents/skills/mistship-conventional-commit-writer/SKILL.md
+++ b/.agents/skills/mistship-conventional-commit-writer/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: mistship-conventional-commit-writer
+description: Generate a Conventional Commits message for changes in the mistship-manifests repository. Use this skill immediately before creating a git commit or when the user asks for a commit message.
+---
+
+# Conventional Commit Writer
+
+AI がこのリポジトリ向けに Conventional Commits 形式の commit message を作るための指示書です。
+
+目的は、差分の意図が短く一貫して伝わる commit message を安定して生成することです。
+
+## 目的
+
+- commit message の形式を repo 全体でそろえる
+- 変更内容ではなく変更の意図を件名へ載せる
+- AI が曖昧な subject や不適切な type を選ぶことを防ぐ
+
+## 出力対象
+
+AI は、基本的に次のどちらかを返します。
+
+- 1 行の Conventional Commit 件名
+- 必要な場合だけ本文つきの commit message
+
+通常は 1 行で十分です。
+
+## 基本形式
+
+形式は次を使います。
+
+```text
+<type>(<scope>): <subject>
+```
+
+scope が不要なら次を使います。
+
+```text
+<type>: <subject>
+```
+
+破壊的変更なら `!` を付けます。
+
+```text
+<type>(<scope>)!: <subject>
+```
+
+## Type ルール
+
+この repo では次を使います。
+
+- `feat`: 新しい利用者向け機能や新しい運用手順を追加した
+- `fix`: 壊れていた挙動や分かりづらい手順を修正した
+- `docs`: ドキュメントだけを変更した
+- `refactor`: 挙動を変えずに構造や配置を整理した
+- `ci`: GitHub Actions や CI 用検証を変更した
+- `test`: テストや検証用 fixture を追加、更新した
+- `build`: build 入力や生成に関わる仕組みを変更した
+- `chore`: 保守作業や雑多な更新で、`feat` `fix` `refactor` ほど意味が強くない
+- `revert`: 既存 commit を取り消した
+
+迷ったときは、変更したファイル種別ではなく、利用者や開発者から見た影響で type を選びます。
+
+## Scope ルール
+
+scope は必須ではありません。あると差分の主対象が明確になる場合だけ使います。
+
+この repo では次を優先候補にします。
+
+- `nix`: `flake.nix` や dev shell
+- `docs`: `README.md` や `docs/`
+- `scripts`: `scripts/`
+- `bootstrap`: `manifests/bootstrap/` や bootstrap 手順
+- `infra`: `manifests/infra/`
+- `patches`: `patches/`
+- `secrets`: `secrets/` や secret 運用文書
+- `templates`: `templates/`
+- `ci`: `.github/workflows/`
+- `image`: `image.yml`
+- `repo`: repo 全体の整理や rename
+
+単一の明確な対象がない場合は scope を省略します。
+
+## Subject ルール
+
+- 英語で書く
+- 先頭は動詞で始める
+- 命令形または現在形で短く書く
+- 末尾に `.` を付けない
+- 冗長な語を避ける
+- 何を変えたかより、なぜその変更が必要かが分かる表現を優先する
+
+悪い例:
+
+- `docs: update README`
+- `fix: fix kubectl`
+- `chore: miscellaneous changes`
+
+良い例:
+
+- `docs: simplify bootstrap documentation`
+- `fix(nix): prefer repo kubeconfig in dev shell`
+- `ci: replace cluster-operating workflows with bootstrap checks`
+
+## Type の選び方
+
+### `docs`
+
+次のときは `docs` を使います。
+
+- Markdown やコメントだけを変えた
+- 手順の説明、例、表現を直した
+- AI 向け instruction 文書を追加した
+
+ただし、documented behavior ではなく実際の挙動が変わるなら `docs` ではなく `fix` や `feat` を使います。
+
+### `fix`
+
+次のときは `fix` を使います。
+
+- 既存の手順が失敗していた
+- 既存 script や shell 環境が期待どおり動かなかった
+- 既存 manifest や patch の不整合を直した
+
+### `feat`
+
+次のときは `feat` を使います。
+
+- これまでなかった bootstrap 機能や運用補助を追加した
+- 新しい manifest 群や script を導入した
+
+### `refactor`
+
+次のときは `refactor` を使います。
+
+- 挙動を変えずに file 配置や構造を整理した
+- script や manifest の責務分離を行った
+
+### `chore`
+
+次のときは `chore` を使います。
+
+- 小さな保守作業
+- version pin 更新
+- generated ではないが利用者影響の弱い雑多な整理
+
+`fix` や `refactor` と説明できるなら、そちらを優先します。
+
+## 本文ルール
+
+本文は必要なときだけ付けます。
+
+次の場合は本文を付けます。
+
+- 複数の変更点があり、件名だけでは意図が不足する
+- 破壊的変更の移行手順が必要
+- 変更理由を残さないと将来の判断が難しい
+
+本文の行長はおおむね 72 文字以内に保ちます。
+
+例:
+
+```text
+fix(nix): prefer repo kubeconfig in dev shell
+
+Detect kubeconfig files inside the repository before falling back to
+.secret/kubeconfig so local kubectl commands work without extra exports.
+```
+
+## Breaking Change
+
+後方互換性を壊す場合は `!` を付け、必要なら footer も付けます。
+
+```text
+refactor(bootstrap)!: split Calico bootstrap manifests
+
+BREAKING CHANGE: apply paths changed from manifests/calico to
+manifests/bootstrap/calico.
+```
+
+## Repo 固有の判断基準
+
+- `README.md` と `docs/` だけなら、通常は `docs`
+- `flake.nix` による開発体験や既定値の修正は、通常は `fix(nix)` か `chore(nix)`。挙動修正なら `fix` を優先する
+- `scripts/ops/prepare-cluster-access.sh` のような利用手順に直結する script 変更は、通常は `fix(scripts)` か `feat(scripts)`
+- `manifests/bootstrap/` の挙動修正は `fix(bootstrap)`、新規導入は `feat(bootstrap)`
+- repo rename や構造整理は `refactor(repo)` または `docs` を検討する
+
+## 禁止事項
+
+- 差分を列挙しただけの subject にしない
+- `update`, `tweak`, `misc`, `stuff`, `changes` のような曖昧語で終わらせない
+- 複数 type を 1 つの件名へ混ぜない
+- 実際は挙動変更なのに `docs` へ逃がさない
+- secret、token、実 IP、実ホスト名を件名や本文へ書かない
+
+## 出力契約
+
+AI は、最終的に次のどちらかを返します。
+
+- 推奨 commit message を 1 つ
+- 候補が割れる場合のみ、第一候補と第二候補を 1 行ずつ
+
+説明が必要なら 1 から 3 文で理由を添えてよいですが、冗長な解説は不要です。
+
+## 実行コマンド
+
+commit message を作る直前に、repo ルートで次を実行します。
+
+```sh
+git status --short
+git diff --cached --stat
+git diff --cached --name-status
+git diff --cached --no-color --binary
+```
+
+commit 対象は staged diff です。`git diff` のみを実行して unstaged diff を入力にしたり、
+`git diff HEAD` で staged diff と unstaged diff を混ぜたりしません。
+
+staged diff が空の場合は commit message を作らず、先に commit 対象を stage するよう
+利用者へ伝えます。
+
+## 実行手順
+
+1. `git status --short` で staged、unstaged、untracked の状態を把握する
+2. `git diff --cached --stat` と `git diff --cached --name-status` で commit 対象の全体像を確認する
+3. `git diff --cached --no-color --binary` を読み、何が変わったかではなく何を達成したかを要約する
+4. その要約から type を 1 つ選ぶ
+5. 主対象が明確なら scope を付ける
+6. 50 から 72 文字程度で subject を組み立てる
+7. 曖昧語、末尾の句点、差分列挙表現を除く
+8. 必要な場合だけ本文を付ける
+
+## AI への指示文
+
+以下をそのまま commit message 生成エージェントの基本指示として使えます。
+
+```text
+You are a Conventional Commit writer for this repository.
+Read the diff and return the single best commit message.
+Use the format <type>(<scope>): <subject> when scope helps, otherwise <type>: <subject>.
+Prefer these types: feat, fix, docs, refactor, ci, test, build, chore, revert.
+Choose the type from the user-visible intent of the change, not from the file extension.
+Keep the subject in English, imperative, concise, and without a trailing period.
+Avoid vague subjects such as update, tweak, misc, or changes.
+Use docs for documentation-only changes, fix for broken behavior, feat for net-new behavior, and refactor for non-behavioral restructuring.
+Return one message by default. Add a body only when the rationale or migration impact would otherwise be unclear.
+Do not include secrets, tokens, real IP addresses, or real hostnames in the commit message.
+```
+
+## 非対象
+
+この定義には次を含めません。
+
+- commit hook の実装
+- PR title の自動変換
+- release note の生成
+- semantic versioning の自動判定


### PR DESCRIPTION
## Summary
- add the mistship commit secret reviewer skill under `.agents/skills`
- add the mistship conventional commit writer skill under `.agents/skills`
- keep both skills in-repo so future v2 child branches can reuse the same commit workflow helpers

## Why
The v2 work should branch from `v2-based`, and these two skills are meant to be available from the repository itself for safer commit review and more consistent commit messages.

## Test Plan
- [x] reviewed the staged diff to confirm only skill definition files were added
- [x] confirmed no code or runtime behavior changed beyond repository-local skill files
