### PR TITLE
Add myscraper godoc comments

### DIFF
--- a/myscraper/cmd/myscraper/main.go
+++ b/myscraper/cmd/myscraper/main.go
@@ -1,3 +1,7 @@
+// Command myscraper is the entry point for the v2 scraper CLI.
+// It wires the standard flag-based CLI in package cli to a scrape.Service
+// backed by the Playwright browser implementation, and exits with the
+// status code returned by cli.Run.
 package main
 
 import (
@@ -9,6 +13,9 @@ import (
 )
 
 func main() {
+	// Hand argv, stdout, and stderr straight to cli.Run so the CLI stays
+	// testable in isolation. The concrete Browser dependency is injected
+	// here so the cli package does not import the Playwright implementation.
 	os.Exit(cli.Run(
 		os.Args[1:],
 		os.Stdout,

--- a/myscraper/e2e/github_smoke_test.go
+++ b/myscraper/e2e/github_smoke_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/azuki774/myscrapers/myscraper/internal/scrape"
 )
 
+// TestGitHubSmoke is an end-to-end check that the Playwright-backed
+// fetch path can load a real public page (https://github.com),
+// produce a non-empty title containing "GitHub", and write an HTML
+// snapshot that contains the expected <html> marker. The test is
+// gated on PLAYWRIGHT_E2E=1 so unit-only runs stay network-free.
 func TestGitHubSmoke(t *testing.T) {
 	if os.Getenv("PLAYWRIGHT_E2E") != "1" {
 		t.Skip("set PLAYWRIGHT_E2E=1 to run browser smoke test")

--- a/myscraper/internal/browser/playwright.go
+++ b/myscraper/internal/browser/playwright.go
@@ -1,3 +1,8 @@
+// Package browser holds the Playwright-backed implementation of
+// scrape.Browser. It owns the Playwright driver download path,
+// the chromium executable lookup, and the per-request browser
+// lifecycle. The package is kept small so the scrape service can
+// stay free of Playwright-specific types.
 package browser
 
 import (
@@ -10,12 +15,23 @@ import (
 	"github.com/playwright-community/playwright-go"
 )
 
+// PlaywrightBrowser is a zero-value, stateless adapter that satisfies
+// scrape.Browser. It is safe to construct at program start and
+// reuse across requests; per-request state is created by Playwright
+// itself.
 type PlaywrightBrowser struct{}
 
+// InstallDriver downloads (or refreshes) the Playwright Node driver
+// into the directory resolved by runOptions. It is safe to call on
+// every Fetch because the underlying installer is idempotent.
 func InstallDriver() error {
 	return playwright.Install(runOptions())
 }
 
+// runOptions centralizes the Playwright driver configuration: the
+// driver lives under PLAYWRIGHT_DRIVER_PATH when set, otherwise under
+// the repo-local .playwright-driver directory; browser binaries are
+// not managed here because the dev shell supplies chromium directly.
 func runOptions() *playwright.RunOptions {
 	driverDirectory := os.Getenv("PLAYWRIGHT_DRIVER_PATH")
 	if driverDirectory == "" {
@@ -27,6 +43,10 @@ func runOptions() *playwright.RunOptions {
 	}
 }
 
+// chromiumExecutablePath resolves the chromium binary that Playwright
+// should drive. The dev shell puts a system chromium on PATH, so we
+// look it up by name rather than bundling a browser. Order matches
+// the most common package names on Debian, Nix, and macOS.
 func chromiumExecutablePath() (string, error) {
 	for _, candidate := range []string{"chromium", "chromium-browser", "google-chrome", "google-chrome-stable"} {
 		if path, err := exec.LookPath(candidate); err == nil {
@@ -36,6 +56,10 @@ func chromiumExecutablePath() (string, error) {
 	return "", fmt.Errorf("no chromium-compatible browser found in PATH")
 }
 
+// Fetch opens url in a headless (or headed) Chromium driven by
+// Playwright and returns the rendered page snapshot. The browser
+// process is started on each call and torn down before returning so
+// callers do not need to manage Playwright's lifecycle directly.
 func (PlaywrightBrowser) Fetch(ctx context.Context, url string, headless bool) (scrape.PageSnapshot, error) {
 	if err := InstallDriver(); err != nil {
 		return scrape.PageSnapshot{}, fmt.Errorf("install playwright driver: %w", err)

--- a/myscraper/internal/cli/options.go
+++ b/myscraper/internal/cli/options.go
@@ -1,3 +1,7 @@
+// Package cli parses command-line arguments for the myscraper binary and
+// dispatches them to a scrape.Runner. It is kept independent of any
+// concrete browser implementation so the wiring can be exercised from
+// tests via the Runner interface.
 package cli
 
 import (
@@ -6,14 +10,23 @@ import (
 	"io"
 )
 
+// Options is the parsed view of the myscraper command-line flags.
+// OutputPath has a default of "tmp/page.html" applied during flag
+// parsing, so callers only need to fill in URL and Headless.
 type Options struct {
 	URL        string
 	OutputPath string
 	Headless   bool
 }
 
+// ParseArgs converts raw argv-style arguments into a validated Options.
+// It returns an error if flag parsing fails or if the required --url
+// flag is missing. OutputPath falls back to a repo-local default so
+// the most common invocation does not need to specify it.
 func ParseArgs(args []string) (Options, error) {
 	fs := flag.NewFlagSet("myscraper", flag.ContinueOnError)
+	// Discard flag's own usage output so parse errors are reported via
+	// the returned error and can be written to a caller-controlled stream.
 	fs.SetOutput(io.Discard)
 
 	opts := Options{}

--- a/myscraper/internal/cli/options_test.go
+++ b/myscraper/internal/cli/options_test.go
@@ -2,6 +2,9 @@ package cli
 
 import "testing"
 
+// TestParseArgs verifies that ParseArgs rejects an invocation with
+// no --url and applies the documented defaults (OutputPath and
+// Headless) when --url is provided.
 func TestParseArgs(t *testing.T) {
 	t.Run("requires url", func(t *testing.T) {
 		_, err := ParseArgs([]string{"--out", "tmp/page.html"})

--- a/myscraper/internal/cli/run.go
+++ b/myscraper/internal/cli/run.go
@@ -8,10 +8,19 @@ import (
 	"github.com/azuki774/myscrapers/myscraper/internal/scrape"
 )
 
+// Runner is the contract the CLI depends on for executing a scrape.
+// It is satisfied by scrape.Service in production and by fakes in
+// tests, which lets the CLI be unit-tested without a real browser.
 type Runner interface {
 	Run(ctx context.Context, req scrape.Request) (scrape.Result, error)
 }
 
+// Run is the top-level entry point used by cmd/myscraper. It parses
+// the given argv slice, dispatches to the injected Runner, and writes
+// either a one-line "saved" success message to stdout or the error to
+// stderr. The exit code is 0 on success, 1 on a runner error, and 2
+// on argument parsing failure so callers can distinguish the two
+// failure modes.
 func Run(args []string, stdout, stderr io.Writer, runner Runner) int {
 	opts, err := ParseArgs(args)
 	if err != nil {

--- a/myscraper/internal/cli/run_test.go
+++ b/myscraper/internal/cli/run_test.go
@@ -17,6 +17,9 @@ func (f fakeRunner) Run(ctx context.Context, req scrape.Request) (scrape.Result,
 	return f.result, f.err
 }
 
+// TestRunPrintsSavedPath verifies that cli.Run returns exit code 0
+// on success and writes the expected "saved <path> (<title>)" line
+// to stdout when the injected Runner reports a successful Result.
 func TestRunPrintsSavedPath(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/myscraper/internal/scrape/service.go
+++ b/myscraper/internal/scrape/service.go
@@ -1,3 +1,8 @@
+// Package scrape defines the Browser interface, request/result
+// payloads, and a Service that drives a Browser and writes its HTML
+// snapshot to disk. The CLI layer talks to Service through these
+// types so the concrete browser implementation (Playwright or a test
+// fake) can be swapped without changing the CLI.
 package scrape
 
 import (
@@ -7,31 +12,52 @@ import (
 	"path/filepath"
 )
 
+// Browser is the minimum capability the scrape service needs: open a
+// URL with a real browser engine and return the rendered snapshot.
+// Implementations live in package browser; tests use a fake.
 type Browser interface {
 	Fetch(ctx context.Context, url string, headless bool) (PageSnapshot, error)
 }
 
+// PageSnapshot is the result of fetching a single page: where the
+// browser ended up (URL may differ from the requested URL after
+// redirects), the rendered <title>, and the full HTML body.
 type PageSnapshot struct {
 	URL   string
 	Title string
 	HTML  string
 }
 
+// Request is the input to Service.Run: the URL to fetch, the file the
+// HTML should be written to, and whether the browser should run
+// without a visible window.
 type Request struct {
 	URL        string
 	OutputPath string
 	Headless   bool
 }
 
+// Result is the success view returned to the caller. Only the data
+// the CLI needs to print is included; the full HTML stays on disk.
 type Result struct {
 	Title      string
 	OutputPath string
 }
 
+// Service runs a single scrape request end-to-end: delegate the
+// browser work to a Browser, ensure the output directory exists,
+// and write the HTML snapshot to disk. It is intentionally a
+// dependency-injection-friendly value type so the CLI can hand it
+// any Browser implementation.
 type Service struct {
 	Browser Browser
 }
 
+// Run executes a Request. It returns an error if no Browser has been
+// configured, the Browser fails, or the output cannot be written.
+// The output file is created with mode 0644; callers that handle
+// sensitive HTML (e.g. authenticated financial statements) should
+// not reuse this path and must tighten permissions themselves.
 func (s Service) Run(ctx context.Context, req Request) (Result, error) {
 	if s.Browser == nil {
 		return Result{}, fmt.Errorf("browser is required")
@@ -42,6 +68,8 @@ func (s Service) Run(ctx context.Context, req Request) (Result, error) {
 		return Result{}, err
 	}
 
+	// Create the parent directory before WriteFile so callers can pass
+	// paths under not-yet-existing tmp/-style directories.
 	if err := os.MkdirAll(filepath.Dir(req.OutputPath), 0o755); err != nil {
 		return Result{}, err
 	}

--- a/myscraper/internal/scrape/service_test.go
+++ b/myscraper/internal/scrape/service_test.go
@@ -16,6 +16,9 @@ func (f fakeBrowser) Fetch(ctx context.Context, url string, headless bool) (Page
 	return f.snapshot, f.err
 }
 
+// TestServiceRunWritesHTML verifies that Service.Run delegates to
+// its Browser, writes the returned HTML bytes to the requested
+// OutputPath verbatim, and surfaces the snapshot's title on success.
 func TestServiceRunWritesHTML(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "page.html")
 	svc := Service{


### PR DESCRIPTION
Add human-readable godoc comments to the existing myscraper Go packages and light godoc to the e2e test functions.

Comments cover all exported symbols across cmd/myscraper, internal/cli, internal/scrape, and internal/browser, plus sparse WHY comments on the non-obvious parts of Service.Run (output directory creation, 0644 file mode caveat for sensitive HTML) and the Playwright driver / chromium lookup helpers. Test functions gain a one-line doc string so their intent is clear from `go doc`.

No behavior change: gofmt, go vet, go test ./..., and go build ./... all pass via `nix develop -c ...`. The only e2e test, TestGitHubSmoke, skips as usual without PLAYWRIGHT_E2E=1.