### PR TITLE
docs(repo): add pull request template and agent skill

### DIFF
--- a/.agents/skills/pr-template-filler/SKILL.md
+++ b/.agents/skills/pr-template-filler/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: pr-template-filler
+description: Walk the agent through the repository's pull request template and validate the result before opening a PR. Use this skill immediately before opening a PR with `gh pr create` or when the user asks the agent to draft a PR description.
+---
+
+# Pull Request Template Filler
+
+## Purpose
+
+Make every pull request in this repository use the same template and contain the information reviewers need. The agent should produce a complete PR description, not a stub.
+
+## When to load
+
+- Before opening a PR with `gh pr create` (or the GitHub web UI)
+- Before drafting a PR description for the user to review
+- Whenever the user asks the agent to "open a PR", "draft a PR", or "prepare a PR"
+
+## Source of truth
+
+The template is `.github/PULL_REQUEST_TEMPLATE.md` at the repository root. Read that file at the start of this skill and treat it as the contract for what the PR description must contain.
+
+## Required sections
+
+The PR description must include, in this order, the following sections. Each must have real content, not placeholders.
+
+- Summary
+- Changes
+- Test
+- Note
+
+## Walkthrough
+
+1. Read `.github/PULL_REQUEST_TEMPLATE.md` to confirm the current section set.
+2. Run `git status` and `git diff --stat` to understand the staged and unstaged changes that will go into the PR.
+3. If a design doc exists at `docs/superpowers/specs/` or an implementation plan at `docs/superpowers/plans/`, read it for the Note section.
+4. For each required section, draft concrete content based on the actual diff and any linked issue or plan.
+5. If a section genuinely does not apply, say so explicitly (for example: "No documentation changes were needed."). Do not leave it blank.
+
+## Validation
+
+After drafting the PR description, check it against the following rules. If any are true, fix the draft before opening the PR.
+
+- Any section is empty, contains only an `<!-- ... -->` comment, or contains placeholders such as `TBD`, `TODO`, `FIXME`, or `N/A` without an explanation.
+- The Summary is missing, is a single word, or is just a restatement of the commit message subject.
+- The Changes section does not list the user-visible changes (a bullet list is preferred).
+- The Test section does not list at least one concrete verification step (a command run, a scenario tested, or output from `go test`, `pytest`, or similar).
+- The Note section does not state the rationale for the change, link an issue, design doc, or implementation plan, or explain why none exist. If the PR is exploratory, write `None` and add one sentence explaining why.
+
+## Commands
+
+Run these from the repository root before opening the PR:
+
+```sh
+git status
+git diff --stat
+git log --oneline -10
+gh pr create --draft --fill --body-file <prepared-body>.md
+```
+
+## Subagent instructions
+
+The following prompt can be used to dispatch a subagent to fill the PR template.
+
+```text
+You are a pull request template filler for this repository.
+Read .github/PULL_REQUEST_TEMPLATE.md and treat it as the contract.
+Draft a PR description for the current branch.
+For each required section (Summary, Changes, Test, Note), write real content based on the diff and any linked issue, design doc, or implementation plan.
+Do not leave placeholders such as TBD, TODO, FIXME, or empty HTML comments. If a section does not apply, say so in one sentence.
+After drafting, validate the description against the rules in the pr-template-filler skill and fix any issues before returning.
+Return the full PR description as markdown, ready to paste into `gh pr create --body-file`.
+```
+
+## Out of scope
+
+- CI-side enforcement (linting the PR body in GitHub Actions)
+- Multiple templates per change type
+- Backporting older PRs to the new template
+- Auto-generating the PR title (use the `mistship-conventional-commit-writer` skill for commit message style)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- One or two sentences describing what this PR does. -->
+
+## Changes
+
+<!-- List the user-visible changes in this PR. -->
+
+- 
+
+## Test
+
+<!-- How was this change verified? Include commands run, scenarios tested, and their results. -->
+
+- [ ] `nix develop -c go test ./...` (for Go changes)
+- [ ] `pytest` (for Python changes under `src/`)
+- [ ] Manual verification (describe what you ran and what you saw)
+
+## Note
+
+<!-- Why is this change needed? Link the related issue, design doc, or implementation plan. If none, write "None" and explain. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Purpose
+
+This repository contains both legacy Python scrapers and a new Go-based v2 scaffold.
+Use this file as the default instruction set for AI agents working in this repo.
+
+## Skills
+
+- Check the repository-local skills under `.agents/skills/` and use them when they are relevant to the task.
+- Prefer reusing existing skill guidance over inventing a new workflow for commits or reviews.
+
+## Tooling
+
+- Prefer running repository tools through Nix so commands use the expected versions and environment.
+- Use `nix develop -c <command>` for one-off commands, or enter `nix develop` before running multiple repo tools.
+
+## Go Changes
+
+- If you modify Go code, run a self-test with a `go test` command before finishing the task.
+- For the current Go scaffold, run tests from `myscraper`, typically with `nix develop -c go test ./...`.
+
+## Pull Requests
+
+- Open pull requests from a feature branch into `master` (or the agreed base branch).
+- The PR description must follow `.github/PULL_REQUEST_TEMPLATE.md`. Use the sections defined there.
+- Before opening a PR, load the `pr-template-filler` skill from `.agents/skills/` and follow it. The skill walks through the template and validates the description.
+- Do not open a PR with empty sections, `TBD`, `TODO`, or `FIXME` placeholders. If a section does not apply, write a one-sentence reason instead of leaving it blank.
+- Link the related issue, design doc, or implementation plan in the Note section. If none, write `None` and explain.


### PR DESCRIPTION
## Summary

Add a single pull request template and a repo-local agent skill that enforces it. Agents opening a PR are now expected to load `pr-template-filler` and produce a complete description with the four required sections (Summary, Changes, Test, Note).

## Changes

- Add `.github/PULL_REQUEST_TEMPLATE.md` with four sections: Summary, Changes, Test, Note
- Add `.agents/skills/pr-template-filler/SKILL.md` that walks agents through the template and validates the result (no `TBD` / `TODO` / `FIXME`, real test steps, issue or plan link or explicit `None`)
- Add `## Pull Requests` section to `AGENTS.md` pointing agents to the template and the new skill

## Test

- Read each of the three files back end-to-end and confirmed the section names in the template match the skill's required-sections list and the AGENTS.md reference
- Ran `git status` and `git diff --stat` to confirm only the three target files are in the PR (no unrelated plan or godoc work mixed in)
- Wrote this PR description by following the template manually
- No Go or Python code was changed, so `go test` and `pytest` are not applicable here

## Note

None. This is a self-contained docs/process change with no related issue, design doc, or implementation plan. The PR template was developed interactively and landed as a single commit on a fresh branch from `master`.
