### PR TITLE
docs(agents): switch agent workflow to direnv-activated shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ myscraper/myscraper
 go/myscraper/.playwright/
 go/myscraper/tmp/
 go/myscraper/myscraper
+
+# Local git worktrees
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,12 +13,13 @@ Use this file as the default instruction set for AI agents working in this repo.
 ## Tooling
 
 - Prefer running repository tools through Nix so commands use the expected versions and environment.
-- Use `nix develop -c <command>` for one-off commands, or enter `nix develop` before running multiple repo tools.
+- The repo's `.envrc` is `use flake`, so `direnv allow` once per checkout (or per worktree) activates the same `nix develop` shell that `nix develop -c` would. After that, run repo tools directly (e.g. `go test -v ./...`, `gopls`, `playwright install chromium`) without prefixing every command with `nix develop -c`.
+- `nix develop -c <command>` is still acceptable for one-off invocations from outside a direnv-activated shell, but in-session work should rely on the active shell.
 
 ## Go Changes
 
 - If you modify Go code, run a self-test with a `go test` command before finishing the task.
-- For the current Go scaffold, run tests from `myscraper`, typically with `nix develop -c go test ./...`.
+- For the current Go scaffold, run tests from `myscraper` with `go test -v ./...`. The active direnv shell supplies the Go toolchain pinned in `flake.nix`.
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary

Update `AGENTS.md` so AI agents activate the Nix dev shell once via `direnv allow` and then run repo tools (e.g. `go test -v ./...`, `gopls`) directly, instead of prefixing every command with `nix develop -c`.

## Changes

- `AGENTS.md` (Tooling section): document the direnv workflow and keep `nix develop -c` as a fallback for one-off invocations.
- `AGENTS.md` (Go Changes section): state the canonical test command as `go test -v ./...` from `myscraper/`, noting that the active direnv shell supplies the Go toolchain pinned in `flake.nix`.

## Test

- [ ] `nix develop -c go test ./...` (not applicable: no Go or Python code changed)
- [ ] `pytest` (not applicable: no Python code changed)
- [x] Manual verification: `direnv allow` in a fresh worktree, then `cd myscraper && go test -v ./...` succeeds (all packages `ok`, all subtests `PASS`) without the `nix develop -c` prefix.
- [x] Manual verification: read the rendered diff end-to-end and confirmed the new Tooling and Go Changes bullets supersede the previous `nix develop -c` guidance without contradicting it.

## Note

None. This is a process-only change triggered by a workflow preference (one `direnv allow` per checkout, then plain commands), with no related issue, design doc, or implementation plan linked.
