### PR TITLE
fix(myscraper): click this month button before extracting CF data

### DIFF
--- a/myscraper/internal/moneyforward/fetch.go
+++ b/myscraper/internal/moneyforward/fetch.go
@@ -19,6 +19,7 @@ const (
 	assetFilename       = "asset_history.csv"
 	cfNowDebugFilename  = "cf_now_debug.html"
 	cfLastDebugFilename = "cf_lastmonth_debug.html"
+	thisMonthXPath      = "/html/body/div[1]/div[2]/div/div/section/div[2]/button[3]"
 	lastMonthXPath      = "/html/body/div[1]/div[2]/div/div/section/div[2]/button[1]"
 	cookiePrimSleep     = 10 * time.Second
 	postClickSleep      = 5 * time.Second
@@ -77,6 +78,15 @@ func Fetch(ctx context.Context, opts FetchOptions) error {
 	logger.Info("waiting for authenticated CF page", "duration", postClickSleep)
 	if err := opts.Session.Wait(ctx, postClickSleep); err != nil {
 		return fmt.Errorf("wait after re-goto cf: %w", err)
+	}
+
+	logger.Info("clicking this month button")
+	if err := opts.Session.ClickByXPath(ctx, thisMonthXPath); err != nil {
+		return fmt.Errorf("click this month: %w", err)
+	}
+	logger.Info("waiting after this month click", "duration", postClickSleep)
+	if err := opts.Session.Wait(ctx, postClickSleep); err != nil {
+		return fmt.Errorf("wait after this month click: %w", err)
 	}
 
 	logger.Info("extracting current month HTML")

--- a/myscraper/internal/moneyforward/fetch_test.go
+++ b/myscraper/internal/moneyforward/fetch_test.go
@@ -63,13 +63,23 @@ func TestFetchProducesCSVFilesAndCallsExpectedSequence(t *testing.T) {
 	if len(sess.gotCookies) != 1 || sess.gotCookies[0].Name != "sid" {
 		t.Fatalf("AddCookies payload = %+v", sess.gotCookies)
 	}
-	wantWaits := []time.Duration{cookiePrimSleep, postClickSleep, postClickSleep, postClickSleep, postClickSleep}
+	wantWaits := []time.Duration{cookiePrimSleep, postClickSleep, postClickSleep, postClickSleep, postClickSleep, postClickSleep}
 	if len(sess.waited) != len(wantWaits) {
 		t.Fatalf("Wait calls = %v, want %v", sess.waited, wantWaits)
 	}
 	for i := range wantWaits {
 		if sess.waited[i] != wantWaits[i] {
 			t.Fatalf("Wait[%d] = %v, want %v; all waits = %v", i, sess.waited[i], wantWaits[i], sess.waited)
+		}
+	}
+
+	wantClicks := []string{"xpath:" + thisMonthXPath, "xpath:" + lastMonthXPath}
+	if len(sess.clicks) != len(wantClicks) {
+		t.Fatalf("ClickByXPath calls = %v, want %v", sess.clicks, wantClicks)
+	}
+	for i := range wantClicks {
+		if sess.clicks[i] != wantClicks[i] {
+			t.Fatalf("Click[%d] = %v, want %v; all clicks = %v", i, sess.clicks[i], wantClicks[i], sess.clicks)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix the MoneyForward scraper to click the "今月" (this month) button before extracting CF data, ensuring the correct month's data is captured.

## Changes

- Added `thisMonthXPath` constant for the "今月" button
- Click the "今月" button after authentication and before extracting current month HTML
- Updated test to verify the new click sequence (6 Wait calls, 2 ClickByXPath calls)

## Test

- [x] `go test -v ./...` -- all tests pass (22 tests across 5 packages)
- [x] Verified the test now expects the "今月" button click before current month extraction

## Note

The MoneyForward CF page defaults to showing the previous month's data. Without clicking "今月", the scraper was extracting data for the wrong month (e.g., May data when June was expected). This fix ensures the scraper always starts from the current month view.
