### PR TITLE
fix: bake Playwright driver into Docker image

### DIFF
--- a/build/moneyforward/Dockerfile
+++ b/build/moneyforward/Dockerfile
@@ -31,6 +31,12 @@ RUN CGO_ENABLED=0 \
       -ldflags=-buildid= \
       -o /out/myscraper ./cmd/myscraper
 
+# Pre-download the Playwright Node driver so the runtime image does not
+# need Go or network access to install it. The driver version must match
+# playwright-go's expectation (v1.52.0 for playwright-go v0.5200.1).
+ENV PLAYWRIGHT_DRIVER_PATH=/out/playwright-driver
+RUN go run github.com/playwright-community/playwright-go/cmd/playwright@v0.5200.1 install
+
 FROM ${RUNTIME_BASE}
 
 # Debian's `chromium` is on PATH and is the first match in
@@ -47,6 +53,9 @@ RUN apt-get update && \
       libnss3 \
       libfontconfig1 && \
     rm -rf /var/lib/apt/lists/*
+
+ENV PLAYWRIGHT_DRIVER_PATH=/playwright/.driver
+COPY --from=builder /out/playwright-driver ${PLAYWRIGHT_DRIVER_PATH}
 
 RUN useradd --system --uid 10001 --create-home --home-dir /home/myscraper myscraper
 WORKDIR /home/myscraper


### PR DESCRIPTION
## Summary

Pre-download the Playwright Node driver during the Docker build and bake it into the runtime image, eliminating the runtime `please install the driver (v1.52.0) first` error in environments without writeable cache dirs or unrestricted network access (e.g. Kubernetes).

## Changes

- Add a builder-stage step that runs `go run github.com/playwright-community/playwright-go/cmd/playwright@v0.5200.1 install` to download the driver into `/out/playwright-driver`
- `COPY --from=builder` the pre-downloaded driver into `/playwright/.driver` in the runtime image
- Set `PLAYWRIGHT_DRIVER_PATH=/playwright/.driver` as an ENV so the app finds the driver without any runtime download

## Test

- [x] `go test -v ./...` — all unit tests pass (no Go code changed, but verified the existing Playwright session tests still pass)
- [ ] Rebuild the image with `docker build -f build/moneyforward/Dockerfile .` and verify the driver is present at `/playwright/.driver` inside the container
- [ ] Deploy the new image to Kubernetes and confirm the `open session: start playwright: please install the driver (v1.52.0) first` error no longer occurs

## Note

The previous Dockerfile relied on `playwright.Install()` downloading the Node driver at container startup. This works in Docker Compose with a named volume for the driver cache, but fails in Kubernetes where the container filesystem is ephemeral and network egress may be restricted. Baking the driver into the image removes the runtime dependency entirely.
